### PR TITLE
Updated django-piston repository url

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,7 +1,7 @@
 docutils
 Pygments
 sphinx
--e hg+https://bitbucket.org/brodie/django-piston#egg=django-piston
+-e hg+https://bitbucket.org/jespern/django-piston#egg=django-piston
 -e git://github.com/openpolis/piston_mini_client.git#egg=piston_mini_client
 django-debug-toolbar
 fabric

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,11 +1,11 @@
-Django==1.3.1
+Django==1.4.5,<1.5
 South>=0.7.3
 -e git://github.com/carljm/django-model-utils.git#egg=django-model-utils
 -e git://github.com/seldon/django-taggit.git#egg=django-taggit
--e git://github.com/toastdriven/django-haystack.git#egg=django-haystack
+django-haystack==2.0.0
 django-extensions
 -e git://github.com/informaetica/django-voting.git#egg=django-voting
-django-registration
+django-registration==0.8
 -e hg+https://bitbucket.org/ubernostrum/django-profiles#egg=django-profiles
 beautifulsoup
 pysolr
@@ -14,3 +14,4 @@ lxml
 pil
 sorl-thumbnail
 django-social-auth
+django-tinymce


### PR DESCRIPTION
Updated django-piston repository url (Jesper Noehr is the official author)
https://pypi.python.org/pypi/django-piston/0.2.3
